### PR TITLE
Use IsFormatSupported() instead of GetMixFormat()

### DIFF
--- a/src/AudioDeviceManager.cpp
+++ b/src/AudioDeviceManager.cpp
@@ -1,4 +1,4 @@
-#include "pch.h"
+﻿#include "pch.h"
 #include "AudioDeviceManager.h"
 
 #include "AudioDeviceEvent.h"
@@ -208,7 +208,7 @@ namespace SaneAudioRenderer
                     return E_FAIL;
 
                 WAVEFORMATEX* pFormat;
-                ThrowIfFailed(backend->audioClient->GetMixFormat(&pFormat));
+                ThrowIfFailed(backend->audioClient->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, &(*format), &pFormat));
                 SharedWaveFormat mixFormat(pFormat, CoTaskMemFreeDeleter());
 
                 backend->mixFormat = mixFormat;


### PR DESCRIPTION
Allows Windows to output 5.1/7.1 surround if an audio processing object (APO) such as Windows Sonic/Dolby Atmos supports higher channel output's.

Supports Windows 10 Spatial Sound in shared mode.
https://msdn.microsoft.com/en-us/library/windows/desktop/dd370876(v=vs.85).aspx
https://msdn.microsoft.com/en-us/library/windows/desktop/mt807491(v=vs.85).aspx
https://www.reddit.com/r/xboxone/comments/6bzb8w/dolby_atmos_for_headphones_is_now_available_in/djd58ng/

Also quick note, 'ignoreSystemChannelMixer' option should be set to false, else it will not output surround sound with Windows Sonic/Dolby Atmos.